### PR TITLE
[OPS-5937] Fix test to work with PHP 7.3

### DIFF
--- a/tests/construct.phpt
+++ b/tests/construct.phpt
@@ -39,7 +39,7 @@ echo $hoedown->parse($text);
 <p><a href="http://www.php.net/">http://www.php.net/</a></p>
 == options: 0 ==
 
-Warning: Hoedown::__construct() expects parameter 1 to be array, integer given in %s on line %d
+Warning: Hoedown::__construct() expects parameter 1 to be array, int given in %s on line %d
 <h1>php</h1>
 
 <p><a href="http://www.php.net/">http://www.php.net/</a></p>


### PR DESCRIPTION
Fix the hoedown constructor test by matching the expected string to what PHP 7.3 outputs.

See https://github.com/UN-OCHA/docker-images/pull/219